### PR TITLE
configurable requests timeout

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,7 @@ redirect_uri = "http://localhost:8888/callback"  # has to be the same as in spot
 ping_url = ""
 results_dir = "/app/data"
 auth_cache_dir = "/app/auth-cache"
+requests_timeout_seconds = 5
 
 [server]
 host = "0.0.0.0"

--- a/spotify-exporter.py
+++ b/spotify-exporter.py
@@ -77,7 +77,10 @@ def start_oauth_server(config):
 def export_playlists(config):
     ensure_directory(config['results_dir'])
 
-    sp = spotipy.Spotify(auth_manager=get_auth_manager(config))
+    sp = spotipy.Spotify(
+        auth_manager=get_auth_manager(config),
+        requests_timeout=config.get('requests_timeout_seconds', 5)
+    )
     tracks_data = []
     playlist_data = []
     playlists = sp.current_user_playlists()


### PR DESCRIPTION
Requests timeout should be configurable so we can handle slow responses.
5 is a default in Spotipy https://github.com/spotipy-dev/spotipy/blob/d9ec669d5b73710f5d3a3f6aeb32095fc1a48156/spotipy/client.py#L133

xref #1