### PR TITLE
fix None artists for podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ cd spotify-exporter
 
 python3 -m venv .venv
 source .venv/bin/activate
+# source .venv/bin/activate.fish for fish shell
 
 pip3 install -r requirements.txt
 

--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,7 @@ ping_url = ""
 results_dir = "/app/data"
 auth_cache_dir = "/app/auth-cache"
 requests_timeout_seconds = 5
+run_on_start = false # in addition to schedule it runs immediately on script start
 
 [server]
 host = "0.0.0.0"

--- a/spotify-exporter.py
+++ b/spotify-exporter.py
@@ -101,11 +101,11 @@ def export_playlists(config):
                     track = item['track']
                     tracks_data.append({
                         'Playlist ID': playlist['id'],
-                        'Track ID': track.get('id', 'Unknown'),
-                        'Track Name': track.get('name', 'Unknown'),
-                        'Artist(s)': ', '.join(artist.get('name', 'Unknown') for artist in track.get('artists', [])),
-                        'Album': track.get('album', {}).get('name', 'Unknown'),
-                        'Album Release Date': track.get('album', {}).get('release_date', 'Unknown'),
+                        'Track ID': track.get('id') or 'Unknown',
+                        'Track Name': track.get('name') or 'Unknown',
+                        'Artist(s)': ', '.join(artist.get('name') or 'Unknown' for artist in track.get('artists', [])),
+                        'Album': (track.get('album') or {}).get('name', 'Unknown'),
+                        'Album Release Date': (track.get('album') or {}).get('release_date', 'Unknown'),
                     })
                 tracks = sp.next(tracks) if tracks and tracks.get('next') else None
         playlists = sp.next(playlists) if playlists and playlists.get('next') else None
@@ -156,6 +156,9 @@ def main():
     oauth_thread = Thread(target=start_oauth_server, args=(config,))
     oauth_thread.daemon = True
     oauth_thread.start()
+
+    if config.get('run_on_start', False):
+        export_playlists(config)
 
     # Run the cron task
     cron_expression = config.get('schedule', {}).get('cron', "0 1 * * *")


### PR DESCRIPTION
Fix #1

The problem was that the playlist contained a podcast episode, which I didn't have in any of my playlists. In this case `artist.get('name', 'Unknown')` returns `None` and then python crashes trying to merge it. Added better handling `artist.get('name') or 'Unknown`` so that it handles both non-existing name and name = None

Also added `run_on_start` for faster troubleshooting